### PR TITLE
Accessibility Update

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -11,7 +11,8 @@ nav {
       width: $width-nav-item;
       line-height: $height-nav-item;
 
-      &:hover {
+      &:hover,
+	  &:focus  {
          background-color: lighten($color--main-bg, 40%);
       }
    }
@@ -29,16 +30,20 @@ nav {
          background-color: $color-background-nav;
          width: $width-nav-item;
 
-         &:hover {
+         &:hover,
+		 &:focus,
+		 &:focus-within  {
             > ul {
-               visibility: visible;
+               opacity: 1;
+			   height: auto;
             }
          }
 
          > ul {
             position: absolute;
             left: 0;
-            visibility: hidden;
+            opacity: 0;
+			height: 1px;
 
             a {
                height: $height-inner-list-items;


### PR DESCRIPTION
- Apply `hover` style to focus state of a link
- Apply `hover` style to focus and `focus-within` states of sub-menu
- Rewrite visibility with accessible method: `opacity` and `height`

Links
- [Designing Focus Indicators](https://www.deque.com/blog/give-site-focus-tips-designing-usable-focus-indicators/)
- [Accessible Drop Down Menus with :focus-within](https://www.scottohara.me/blog/2017/05/14/focus-within.html)